### PR TITLE
fix: type inference on fedora

### DIFF
--- a/Sources/SwiftEccodes/SwiftEccodes.swift
+++ b/Sources/SwiftEccodes/SwiftEccodes.swift
@@ -39,7 +39,7 @@ public struct SwiftEccodes {
     /// Return all messages. Load the entire file into memory.
     public static func getMessages(fileHandle: FileHandle, multiSupport: Bool) throws -> [GribMessage] {
         let c = getContext(multiSupport: multiSupport)
-        let fn:  UnsafeMutablePointer<FILE>! = fdopen(dup(fileHandle.fileDescriptor), "r")
+        let fn: UnsafeMutablePointer<FILE>! = fdopen(dup(fileHandle.fileDescriptor), "r")
         defer { fclose(fn) }
         
         var messages = [GribMessage]()

--- a/Sources/SwiftEccodes/SwiftEccodes.swift
+++ b/Sources/SwiftEccodes/SwiftEccodes.swift
@@ -39,7 +39,7 @@ public struct SwiftEccodes {
     /// Return all messages. Load the entire file into memory.
     public static func getMessages(fileHandle: FileHandle, multiSupport: Bool) throws -> [GribMessage] {
         let c = getContext(multiSupport: multiSupport)
-        let fn = fdopen(dup(fileHandle.fileDescriptor), "r")
+        let fn:  UnsafeMutablePointer<FILE>! = fdopen(dup(fileHandle.fileDescriptor), "r")
         defer { fclose(fn) }
         
         var messages = [GribMessage]()


### PR DESCRIPTION
For some reason there was an issue with type-inference when building on Fedora. Swift inferred the type to be `UnsafeMutablePointer<FILE>?` instead of ` UnsafeMutablePointer<FILE>!`.